### PR TITLE
feat: custom styles in richtext editor

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -479,9 +479,10 @@ EOT;
      */
     private function addRichTextSection(ArrayNodeDefinition $rootNode)
     {
-        $this->addCustomTagsSection(
-            $rootNode->children()->arrayNode('ezrichtext')->children()
-        )->end()->end()->end();
+        $ezRichTextNode = $rootNode->children()->arrayNode('ezrichtext')->children();
+        $this->addCustomTagsSection($ezRichTextNode);
+        $this->addCustomStylesSection($ezRichTextNode);
+        $ezRichTextNode->end()->end()->end();
     }
 
     /**
@@ -564,6 +565,41 @@ EOT;
                                     ->end()
                                 ->end()
                             ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+
+    /**
+     * Define RichText Custom Styles Semantic Configuration.
+     *
+     * The configuration is available at:
+     * <code>
+     * ezpublish:
+     *     ezrichtext:
+     *         custom_styles:
+     * </code>
+     *
+     * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $ezRichTextNode
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition
+     */
+    private function addCustomStylesSection(NodeBuilder $ezRichTextNode)
+    {
+        return $ezRichTextNode
+                ->arrayNode('custom_styles')
+                // workaround: take into account Custom Tag names when merging configs
+                ->useAttributeAsKey('style')
+                ->arrayPrototype()
+                    ->children()
+                        ->scalarNode('template')
+                            ->defaultNull()
+                        ->end()
+                        ->scalarNode('inline')
+                            ->defaultFalse()
                         ->end()
                     ->end()
                 ->end()

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
@@ -167,6 +167,13 @@ class RichText extends AbstractFieldTypeParser
                 ->info('List of RichText Custom Tags enabled for the current scope. The Custom Tags must be defined in ezpublish.ezrichtext.custom_tags Node.')
                 ->scalarPrototype()->end()
             ->end();
+
+        // RichText Custom Styles configuration (list of Custom Styles enabled for current SiteAccess scope)
+        $nodeBuilder
+            ->arrayNode('custom_styles')
+                ->info('List of RichText Custom Styles enabled for the current scope. The Custom Styles must be defined in ezpublish.ezrichtext.custom_styles Node.')
+                ->scalarPrototype()->end()
+            ->end();
     }
 
     /**
@@ -217,6 +224,17 @@ class RichText extends AbstractFieldTypeParser
                     $scopeSettings['fieldtypes']['ezrichtext']['custom_tags']
                 );
             }
+            if (isset($scopeSettings['fieldtypes']['ezrichtext']['custom_styles'])) {
+                $this->validateCustomStylesConfiguration(
+                    $contextualizer->getContainer(),
+                    $scopeSettings['fieldtypes']['ezrichtext']['custom_styles']
+                );
+                $contextualizer->setContextualParameter(
+                    'fieldtypes.ezrichtext.custom_styles',
+                    $currentScope,
+                    $scopeSettings['fieldtypes']['ezrichtext']['custom_styles']
+                );
+            }
 
             if (isset($scopeSettings['fieldtypes']['ezrichtext']['tags'])) {
                 foreach ($scopeSettings['fieldtypes']['ezrichtext']['tags'] as $name => $tagSettings) {
@@ -264,6 +282,28 @@ class RichText extends AbstractFieldTypeParser
             if (!in_array($customTagName, $definedCustomTags)) {
                 throw new InvalidConfigurationException(
                     "Unknown RichText Custom Tag '{$customTagName}'"
+                );
+            }
+        }
+    }
+
+    /**
+     * Validate SiteAccess-defined Custom Styles configuration against global one.
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+     * @param array $enabledCustomStyles List of Custom Styles enabled for the current scope/SiteAccess
+     */
+    private function validateCustomStylesConfiguration(
+        ContainerInterface $container,
+        array $enabledCustomStyles
+    ) {
+        $definedCustomStyles = array_keys(
+            $container->getParameter(EzPublishCoreExtension::RICHTEXT_CUSTOM_STYLES_PARAMETER)
+        );
+        foreach ($enabledCustomStyles as $customStyleName) {
+            if (!in_array($customStyleName, $definedCustomStyles)) {
+                throw new InvalidConfigurationException(
+                    "Unknown RichText Custom Style '{$customStyleName}'"
                 );
             }
         }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -27,6 +27,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterf
 
 class EzPublishCoreExtension extends Extension
 {
+    const RICHTEXT_CUSTOM_STYLES_PARAMETER = 'ezplatform.ezrichtext.custom_styles';
     const RICHTEXT_CUSTOM_TAGS_PARAMETER = 'ezplatform.ezrichtext.custom_tags';
 
     /**
@@ -295,6 +296,12 @@ class EzPublishCoreExtension extends Extension
             $container->setParameter(
                 static::RICHTEXT_CUSTOM_TAGS_PARAMETER,
                 $config['ezrichtext']['custom_tags']
+            );
+        }
+        if (isset($config['ezrichtext']['custom_styles'])) {
+            $container->setParameter(
+                static::RICHTEXT_CUSTOM_STYLES_PARAMETER,
+                $config['ezrichtext']['custom_styles']
             );
         }
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -25,6 +25,11 @@ parameters:
     # Rich Text Custom Tags default scope (for SiteAccess) configuration
     ezsettings.default.fieldtypes.ezrichtext.custom_tags: []
 
+    # Rich Text Custom Styles global configuration
+    ezplatform.ezrichtext.custom_styles: {}
+    # Rich Text Custom Styles default scope (for SiteAccess) configuration
+    ezsettings.default.fieldtypes.ezrichtext.custom_styles: []
+
     ezsettings.default.pagelayout: 'EzPublishCoreBundle::pagelayout.html.twig'
 
     # List of content type identifiers to display as image when embedded
@@ -116,6 +121,13 @@ parameters:
         template: EzPublishCoreBundle:FieldType/RichText/tag:default.html.twig
     ezsettings.default.fieldtypes.ezrichtext.tags.default_inline:
         template: EzPublishCoreBundle:FieldType/RichText/tag:default_inline.html.twig
+
+    # RichText field type template style settings
+    # 'default' and 'default_inline' tag identifiers are reserved for fallback
+    ezsettings.default.fieldtypes.ezrichtext.styles.default:
+        template: EzPublishCoreBundle:FieldType/RichText/style:default.html.twig
+    ezsettings.default.fieldtypes.ezrichtext.styles.default_inline:
+        template: EzPublishCoreBundle:FieldType/RichText/style:default_inline.html.twig
 
     # RichText field type embed settings
     ezsettings.default.fieldtypes.ezrichtext.embed.content:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -21,9 +21,11 @@ parameters:
     ezpublish.fieldType.ezrichtext.converter.link.class: eZ\Publish\Core\FieldType\RichText\Converter\Link
     ezpublish.fieldType.ezrichtext.converter.embed.class: eZ\Publish\Core\FieldType\RichText\Converter\Render\Embed
     ezpublish.fieldType.ezrichtext.converter.template.class: eZ\Publish\Core\FieldType\RichText\Converter\Render\Template
+    ezpublish.fieldType.ezrichtext.converter.style.class: eZ\Publish\Core\FieldType\RichText\Converter\Render\Style
     ezpublish.fieldType.ezrichtext.embed_renderer.class: eZ\Publish\Core\MVC\Symfony\FieldType\RichText\EmbedRenderer
     ezpublish.fieldType.ezrichtext.renderer.class: eZ\Publish\Core\MVC\Symfony\FieldType\RichText\Renderer
     ezpublish.fieldType.ezrichtext.tag.namespace: fieldtypes.ezrichtext.tags
+    ezpublish.fieldType.ezrichtext.style.namespace: fieldtypes.ezrichtext.styles
     ezpublish.fieldType.ezrichtext.embed.namespace: fieldtypes.ezrichtext.embed
     ezpublish.fieldType.ezrichtext.converter.dispatcher.class: eZ\Publish\Core\FieldType\RichText\ConverterDispatcher
     ezpublish.fieldType.ezrichtext.validator.xml.class: eZ\Publish\Core\FieldType\RichText\Validator
@@ -143,9 +145,19 @@ services:
             - "@ezpublish.config.resolver"
             - "@templating"
             - "%ezpublish.fieldType.ezrichtext.tag.namespace%"
+            - "%ezpublish.fieldType.ezrichtext.style.namespace%"
             - "%ezpublish.fieldType.ezrichtext.embed.namespace%"
             - "@?logger"
             - "%ezplatform.ezrichtext.custom_tags%"
+            - "%ezplatform.ezrichtext.custom_styles%"
+
+    ezpublish.fieldType.ezrichtext.converter.style:
+        class: "%ezpublish.fieldType.ezrichtext.converter.style.class%"
+        arguments:
+            - "@ezpublish.fieldType.ezrichtext.renderer"
+            - "@ezpublish.fieldType.ezrichtext.converter.output.xhtml5"
+        tags:
+            - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 10}
 
     ezpublish.fieldType.ezrichtext.converter.template:
         class: "%ezpublish.fieldType.ezrichtext.converter.template.class%"

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/style/default.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/style/default.html.twig
@@ -1,0 +1,1 @@
+<div class="{% if align is defined %}align-{{ align }}{% endif %} style-{{ name }}">{% spaceless %}{{ content|raw }}{% endspaceless %}</div>

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/style/default_inline.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/style/default_inline.html.twig
@@ -1,0 +1,1 @@
+<span class="style-{{ name }}">{% spaceless %}{{ content|raw }}{% endspaceless %}</span>

--- a/eZ/Publish/Core/FieldType/RichText/Converter/Render/Style.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Render/Style.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * File containing the eZ\Publish\Core\FieldType\RichText\Converter\Render\Style class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license   For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\RichText\Converter\Render;
+
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMXPath;
+use eZ\Publish\Core\FieldType\RichText\Converter;
+use eZ\Publish\Core\FieldType\RichText\Converter\Render;
+use eZ\Publish\Core\FieldType\RichText\RendererInterface;
+
+/**
+ * RichText Style converter injects rendered style payloads into style elements.
+ */
+class Style extends Render implements Converter
+{
+    /**
+     * @var Converter
+     */
+    private $richTextConverter;
+
+    /**
+     * Style constructor.
+     *
+     * @param RendererInterface $renderer
+     * @param Converter         $richTextConverter
+     */
+    public function __construct(RendererInterface $renderer, Converter $richTextConverter)
+    {
+        $this->richTextConverter = $richTextConverter;
+        parent::__construct($renderer);
+    }
+
+    /**
+     * Injects rendered payloads into template tag elements.
+     *
+     * @param \DOMDocument $document
+     *
+     * @return \DOMDocument
+     */
+    public function convert(DOMDocument $document)
+    {
+        $xpath = new DOMXPath($document);
+        $xpath->registerNamespace('docbook', 'http://docbook.org/ns/docbook');
+        $xpathExpression = '//docbook:ezstyle | //docbook:ezstyleinline';
+
+        $styles = $xpath->query($xpathExpression);
+        /** @var \DOMElement[] $stylesSorted */
+        $stylesSorted = [];
+        $maxDepth = 0;
+
+        foreach ($styles as $style) {
+            $depth = $this->getNodeDepth($style);
+            if ($depth > $maxDepth) {
+                $maxDepth = $depth;
+            }
+            $stylesSorted[$depth][] = $style;
+        }
+
+        ksort($stylesSorted, SORT_NUMERIC);
+        foreach ($stylesSorted as $styles) {
+            foreach ($styles as $style) {
+                $this->processStyle($document, $style);
+            }
+        }
+
+        return $document;
+    }
+
+    /**
+     * Processes given template $style in a given $document.
+     *
+     * @param \DOMDocument $document
+     * @param \DOMElement  $style
+     */
+    protected function processStyle(DOMDocument $document, DOMElement $style)
+    {
+        $content = null;
+        $styleName = $style->getAttribute('name');
+        $parameters = [
+            'name' => $styleName,
+            'content' => $this->saveNodeXML($style),
+        ];
+
+        if ($style->hasAttribute('ezxhtml:align')) {
+            $parameters['align'] = $style->getAttribute('ezxhtml:align');
+        }
+
+        $content = $this->renderer->renderStyle(
+            $styleName,
+            $parameters,
+            $style->localName === 'ezstyleinline'
+        );
+
+        if (isset($content)) {
+            // If current tag is wrapped inside another template tag we can't use CDATA section
+            // for its content as these can't be nested.
+            // CDATA section will be used only for content of root wrapping tag, content of tags
+            // inside it will be added as XML fragments.
+            if ($this->isWrapped($style)) {
+                $fragment = $document->createDocumentFragment();
+                $fragment->appendXML($content);
+                $style->parentNode->replaceChild($fragment, $style);
+            } else {
+                $payload = $document->createElement('ezpayload');
+                $payload->appendChild($document->createCDATASection($content));
+                $style->appendChild($payload);
+            }
+        }
+    }
+
+    /**
+     * Returns if the given $node is wrapped inside another template node.
+     *
+     * @param \DOMNode $node
+     *
+     * @return bool
+     */
+    protected function isWrapped(DomNode $node)
+    {
+        while ($node = $node->parentNode) {
+            if ($node->localName === 'ezstyle' || $node->localName === 'ezstyleinline') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns depth of given $node in a DOMDocument.
+     *
+     * @param \DOMNode $node
+     *
+     * @return int
+     */
+    protected function getNodeDepth(DomNode $node)
+    {
+        $depth = -2;
+
+        while ($node) {
+            ++$depth;
+            $node = $node->parentNode;
+        }
+
+        return $depth;
+    }
+
+    /**
+     * Returns XML fragment string for given $node.
+     *
+     * @param \DOMNode $node
+     *
+     * @return string
+     */
+    protected function saveNodeXML(DOMNode $node)
+    {
+        $innerDoc = new DOMDocument();
+
+        /** @var \DOMNode $child */
+        foreach ($node->childNodes as $child) {
+            $innerDoc->appendChild($innerDoc->importNode($child, true));
+        }
+
+        return $this->richTextConverter->convert($innerDoc)->saveHTML();
+    }
+}

--- a/eZ/Publish/Core/FieldType/RichText/RendererInterface.php
+++ b/eZ/Publish/Core/FieldType/RichText/RendererInterface.php
@@ -14,6 +14,17 @@ namespace eZ\Publish\Core\FieldType\RichText;
 interface RendererInterface
 {
     /**
+     * Renders template style.
+     *
+     * @param string $name
+     * @param array $parameters
+     * @param bool $isInline
+     *
+     * @return string
+     */
+    public function renderStyle($name, array $parameters, $isInline);
+
+    /**
      * Renders template tag.
      *
      * @param string $name

--- a/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng
@@ -610,6 +610,61 @@
     </define>
   </div>
 
+  <div>
+    <a:documentation>
+      eZ Publish custom styles
+    </a:documentation>
+    <define name="ez.style">
+      <element name="ezstyle">
+        <ref name="ez.style.contentmodel"/>
+      </element>
+    </define>
+    <define name="ez.styleinline">
+      <element name="ezstyleinline">
+        <ref name="ez.style.contentmodel.inline"/>
+      </element>
+    </define>
+    <define name="ez.style.contentmodel">
+      <ref name="ez.style.attlist"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="db.all.inlines"/>
+          <ref name="db.recursive.blocks.or.sections"/>
+        </choice>
+      </zeroOrMore>
+    </define>
+    <define name="ez.style.contentmodel.inline">
+      <ref name="ez.style.attlist.inline"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="db.all.inlines"/>
+        </choice>
+      </zeroOrMore>
+    </define>
+    <define name="ez.style.attlist.inline">
+      <ref name="ez.style.attributes.inline"/>
+    </define>
+    <define name="ez.style.attributes.inline">
+      <attribute name="name">
+        <data type="string">
+          <param name="pattern">[A-Za-z][A-Za-z0-9_\-]*</param>
+        </data>
+      </attribute>
+      <optional>
+        <ref name="ez.xhtml.class.attribute"/>
+      </optional>
+    </define>
+    <define name="ez.style.attlist">
+      <ref name="ez.style.attributes"/>
+    </define>
+    <define name="ez.style.attributes">
+      <optional>
+        <ref name="ez.xhtml.align"/>
+      </optional>
+      <ref name="ez.style.attributes.inline"/>
+    </define>
+  </div>
+
   <define name="ez.embed.attributes">
     <ref name="db.xlink.href.attribute"/>
     <optional>
@@ -777,6 +832,7 @@
       <choice>
         <ref name="ez.embedinline"/>
         <ref name="ez.templateinline"/>
+        <ref name="ez.styleinline"/>
         <ref name="ez.extension.inlines"/>
       </choice>
     </zeroOrMore>
@@ -796,6 +852,7 @@
         <ref name="db.title"/>
         <ref name="ez.embed"/>
         <ref name="ez.template"/>
+        <ref name="ez.style"/>
         <ref name="ez.extension.blocks"/>
       </choice>
     </zeroOrMore>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -627,6 +627,34 @@
     </xsl:element>
   </xsl:template>
 
+  <!-- Custom template tag code -->
+  <xsl:template match="docbook:ezstyle">
+    <xsl:element name="div" namespace="{$outputNamespace}">
+      <xsl:if test="@name">
+        <xsl:attribute name="data-style">
+          <xsl:value-of select="@name"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:if test="@ezxhtml:align">
+        <xsl:attribute name="data-ezalign">
+          <xsl:value-of select="@ezxhtml:align"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="docbook:ezstyleinline">
+    <xsl:element name="span" namespace="{$outputNamespace}">
+      <xsl:if test="@name">
+        <xsl:attribute name="data-style">
+          <xsl:value-of select="@name"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
   <xsl:template name="extractStyleValue">
     <xsl:param name="style"/>
     <xsl:param name="property"/>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
@@ -505,6 +505,12 @@
 
   <xsl:template match="docbook:eztemplate | docbook:eztemplateinline"/>
 
+  <xsl:template match="docbook:ezstyle[ezpayload] | docbook:ezstyleinline[ezpayload]">
+    <xsl:value-of select="ezpayload/text()" disable-output-escaping="yes"/>
+  </xsl:template>
+
+  <xsl:template match="docbook:ezstyle | docbook:ezstyleinline"/>
+
   <xsl:template name="extractStyleValue">
     <xsl:param name="style"/>
     <xsl:param name="property"/>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -622,4 +622,27 @@
     <xsl:value-of select="translate( substring-before( substring-after( concat( substring-after( $style, $property ), ';' ), ':' ), ';' ), ' ', '' )"/>
   </xsl:template>
 
+  <xsl:template match="ezxhtml5:div[@data-style]">
+    <xsl:element name="ezstyle" namespace="http://docbook.org/ns/docbook">
+      <xsl:attribute name="name">
+        <xsl:value-of select="@data-style"/>
+      </xsl:attribute>
+      <xsl:if test="@data-ezalign">
+        <xsl:attribute name="ezxhtml:align">
+          <xsl:value-of select="@data-ezalign"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="ezxhtml5:span[@data-style]">
+    <xsl:element name="ezstyleinline" namespace="http://docbook.org/ns/docbook">
+      <xsl:attribute name="name">
+        <xsl:value-of select="@data-style"/>
+      </xsl:attribute>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | 
| **Bug/Improvement**| yes
| **New feature**    | yes
| **Target version** | `7.x`
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | yes

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.


Added a way to declare and use custom "styles" in richtext (https://alloyeditor.com/docs/features/styles.html)

## Configure the custom style


``` yaml
ezpublish:
    system:
        default:
            fieldtypes:
                ezrichtext:
                    custom_styles: [highlighted_block, highlighted_word]
    
    ezrichtext:
        custom_styles:
            highlighted_word:
                template: '@ezdesign/field_type/ezrichtext/custom_style/highlighted_word.html.twig'
                inline: false
            highlighted_block:
                template: '@ezdesign/field_type/ezrichtext/custom_style/highlighted_block.html.twig'
                inline: true
```

### Default templates

Block template :
```twig
<div class="{% if align is defined %}align-{{ align }}{% endif %} style-{{ name }}">{% spaceless %}{{ content|raw }}{% endspaceless %}</div>
```

Inline template :
```twig
<span class="style-{{ name }}">{% spaceless %}{{ content|raw }}{% endspaceless %}</span>
```

## Labels

Custom styles label are generated using SF translation. 
Translation domain is "custom_styles".

``` yaml
ezrichtext.custom_styles.highlighted_block.label: Highlighted block
ezrichtext.custom_styles.highlighted_word.label: Highlighted word
```